### PR TITLE
Read input in _prepare_data properly

### DIFF
--- a/lib/Mastodon/Role/UserAgent.pm
+++ b/lib/Mastodon/Role/UserAgent.pm
@@ -167,7 +167,7 @@ sub _request {
 }
 
 sub _prepare_data {
-  my ($self, $url, $data) = @_;
+  my ($self, $data) = @_;
   $data //= {};
 
   foreach my $key (keys %{$data}) {


### PR DESCRIPTION
Otherwise, `$data` just ends up being an empty hashref and authentication doesn't work.