### PR TITLE
Authorize method fix

### DIFF
--- a/lib/Mastodon/Client.pm
+++ b/lib/Mastodon/Client.pm
@@ -131,7 +131,7 @@ sub authorize {
 
   $data->{scope} = join q{ }, sort @{ $self->scopes };
 
-  my $response = $self->post( 'oauth/token' => $data );
+  my $response = $self->post( '/oauth/token' => $data );
 
   if ( defined $response->{error} ) {
     $log->warn( $response->{error_description} );


### PR DESCRIPTION
Hi,

I noticed that the `authorize` method stopped working - this was working for me previously, but I think the implementation of Mastodon API v2 broke it (the OAuth endpoints are no longer available under `/api/v1`, they are universal.)

This is the easiest fix I could think of, because I just wanted to get my bot working again. If you can think of something more elegant, please do suggest it.

All the best
Lawrence